### PR TITLE
Add llama end to end test with jetstream engine 

### DIFF
--- a/jetstream_pt/third_party/llama2/generation_original.py
+++ b/jetstream_pt/third_party/llama2/generation_original.py
@@ -1,0 +1,290 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# This software may be used and distributed according to the terms of the Llama 2 Community License Agreement.
+
+import json
+import os
+import sys
+import time
+from pathlib import Path
+from typing import List, Literal, Optional, Tuple, TypedDict
+
+import torch
+import torch.nn.functional as F
+from fairscale.nn.model_parallel.initialize import (
+    get_model_parallel_rank,
+    initialize_model_parallel,
+    model_parallel_is_initialized,
+)
+
+from jetstream_pt.third_party.llama2 import model_original
+
+from llama.tokenizer import Tokenizer
+
+Role = Literal["system", "user", "assistant"]
+
+
+class Message(TypedDict):
+    role: Role
+    content: str
+
+
+class CompletionPrediction(TypedDict, total=False):
+    generation: str
+    tokens: List[str]  # not required
+    logprobs: List[float]  # not required
+
+
+class ChatPrediction(TypedDict, total=False):
+    generation: Message
+    tokens: List[str]  # not required
+    logprobs: List[float]  # not required
+
+
+Dialog = List[Message]
+
+B_INST, E_INST = "[INST]", "[/INST]"
+B_SYS, E_SYS = "<<SYS>>\n", "\n<</SYS>>\n\n"
+
+SPECIAL_TAGS = [B_INST, E_INST, "<<SYS>>", "<</SYS>>"]
+UNSAFE_ERROR = "Error: special tags are not allowed as part of the prompt."
+
+
+class LlamaOriginal:
+    @staticmethod
+    def build(
+        tokenizer_path: str,
+        model_args: model_original.ModelArgs,
+        seed: int = 1,
+    ) -> "LlamaOriginal":
+
+        local_rank = int(os.environ.get("LOCAL_RANK", 0))
+
+
+        # seed must be the same in all processes
+        torch.manual_seed(seed)
+
+        tokenizer = Tokenizer(model_path=tokenizer_path)
+        model_args.vocab_size = tokenizer.n_words
+        model = model_original.Transformer(model_args)
+
+        return LlamaOriginal(model, tokenizer)
+
+    def __init__(self, model: model_original.Transformer, tokenizer: Tokenizer):
+        self.model = model
+        self.tokenizer = tokenizer
+
+    @torch.inference_mode()
+    def generate(
+        self,
+        prompt_tokens: List[List[int]],
+        max_gen_len: int,
+    ) -> List[List[int]]:
+        """
+        Do greedy search on CPU and return tokens only. 
+        """
+         
+        params = self.model.params
+        bsz = len(prompt_tokens)
+        assert bsz <= params.max_batch_size, (bsz, params.max_batch_size)
+
+        min_prompt_len = min(len(t) for t in prompt_tokens)
+        max_prompt_len = max(len(t) for t in prompt_tokens)
+        assert max_prompt_len <= params.max_seq_len
+        total_len = min(params.max_seq_len, max_gen_len + max_prompt_len)
+
+        pad_id = self.tokenizer.pad_id
+        tokens = torch.full((bsz, total_len), pad_id, dtype=torch.long, device="cpu")
+        for k, t in enumerate(prompt_tokens):
+            tokens[k, : len(t)] = torch.tensor(t, dtype=torch.long, device="cpu")
+    
+
+        prev_pos = 0
+        eos_reached = torch.tensor([False] * bsz, device="cpu")
+        input_text_mask = tokens != pad_id
+
+        for cur_pos in range(min_prompt_len, total_len):
+            logits = self.model.forward(tokens[:, prev_pos:cur_pos], prev_pos)
+            next_token = torch.argmax(logits[:, -1], dim=-1)
+
+            next_token = next_token.reshape(-1)
+            # only replace token if prompt has already been generated
+            next_token = torch.where(
+                input_text_mask[:, cur_pos], tokens[:, cur_pos], next_token
+            )
+            tokens[:, cur_pos] = next_token
+            eos_reached |= (~input_text_mask[:, cur_pos]) & (
+                next_token == self.tokenizer.eos_id
+            )
+            prev_pos = cur_pos
+            if all(eos_reached):
+                break
+
+        out_tokens, out_logprobs = [], []
+        for i, toks in enumerate(tokens.tolist()):
+            # cut to max gen len
+            start = len(prompt_tokens[i])
+            toks = toks[start : len(prompt_tokens[i]) + max_gen_len]
+            probs = None
+            # cut to eos tok if any
+            if self.tokenizer.eos_id in toks:
+                eos_idx = toks.index(self.tokenizer.eos_id)
+                toks = toks[:eos_idx]
+            out_tokens.append(toks)
+            out_logprobs.append(probs)
+        return out_tokens
+
+    def text_completion(
+        self,
+        prompts: List[str],
+        temperature: float = 0.6,
+        top_p: float = 0.9,
+        max_gen_len: Optional[int] = None,
+        logprobs: bool = False,
+        echo: bool = False,
+    ) -> List[CompletionPrediction]:
+        """
+        Perform text completion for a list of prompts using the language generation model.
+
+        Args:
+            prompts (List[str]): List of text prompts for completion.
+            temperature (float, optional): Temperature value for controlling randomness in sampling. Defaults to 0.6.
+            top_p (float, optional): Top-p probability threshold for nucleus sampling. Defaults to 0.9.
+            max_gen_len (Optional[int], optional): Maximum length of the generated completion sequence.
+                If not provided, it's set to the model's maximum sequence length minus 1.
+            logprobs (bool, optional): Flag indicating whether to compute token log probabilities. Defaults to False.
+            echo (bool, optional): Flag indicating whether to include prompt tokens in the generated output. Defaults to False.
+
+        Returns:
+            List[CompletionPrediction]: List of completion predictions, each containing the generated text completion.
+
+        Note:
+            This method generates text completions for the provided prompts, employing nucleus sampling to introduce controlled randomness.
+            If logprobs is True, token log probabilities are computed for each generated token.
+
+        """
+        if max_gen_len is None:
+            max_gen_len = self.model.params.max_seq_len - 1
+        prompt_tokens = [self.tokenizer.encode(x, bos=True, eos=False) for x in prompts]
+        generation_tokens, generation_logprobs = self.generate(
+            prompt_tokens=prompt_tokens,
+            max_gen_len=max_gen_len,
+            temperature=temperature,
+            top_p=top_p,
+            logprobs=logprobs,
+            echo=echo,
+        )
+        return [{"generation": self.tokenizer.decode(t)} for t in generation_tokens]
+
+    def chat_completion(
+        self,
+        dialogs: List[Dialog],
+        temperature: float = 0.6,
+        top_p: float = 0.9,
+        max_gen_len: Optional[int] = None,
+        logprobs: bool = False,
+    ) -> List[ChatPrediction]:
+        """
+        Generate assistant responses for a list of conversational dialogs using the language generation model.
+
+        Args:
+            dialogs (List[Dialog]): List of conversational dialogs, where each dialog is a list of messages.
+            temperature (float, optional): Temperature value for controlling randomness in sampling. Defaults to 0.6.
+            top_p (float, optional): Top-p probability threshold for nucleus sampling. Defaults to 0.9.
+            max_gen_len (Optional[int], optional): Maximum length of the generated response sequence.
+                If not provided, it's set to the model's maximum sequence length minus 1.
+            logprobs (bool, optional): Flag indicating whether to compute token log probabilities. Defaults to False.
+
+        Returns:
+            List[ChatPrediction]: List of chat predictions, each containing the assistant's generated response.
+
+        Raises:
+            AssertionError: If the last message in a dialog is not from the user.
+            AssertionError: If the dialog roles are not in the required 'user', 'assistant', and optional 'system' order.
+
+        Note:
+            This method generates assistant responses for the provided conversational dialogs.
+            It employs nucleus sampling to introduce controlled randomness in text generation.
+            If logprobs is True, token log probabilities are computed for each generated token.
+
+        """
+        if max_gen_len is None:
+            max_gen_len = self.model.params.max_seq_len - 1
+        prompt_tokens = []
+        unsafe_requests = []
+        for dialog in dialogs:
+            unsafe_requests.append(
+                any([tag in msg["content"] for tag in SPECIAL_TAGS for msg in dialog])
+            )
+            if dialog[0]["role"] == "system":
+                dialog = [
+                    {
+                        "role": dialog[1]["role"],
+                        "content": B_SYS
+                        + dialog[0]["content"]
+                        + E_SYS
+                        + dialog[1]["content"],
+                    }
+                ] + dialog[2:]
+            assert all([msg["role"] == "user" for msg in dialog[::2]]) and all(
+                [msg["role"] == "assistant" for msg in dialog[1::2]]
+            ), (
+                "model only supports 'system', 'user' and 'assistant' roles, "
+                "starting with 'system', then 'user' and alternating (u/a/u/a/u...)"
+            )
+            dialog_tokens: List[int] = sum(
+                [
+                    self.tokenizer.encode(
+                        f"{B_INST} {(prompt['content']).strip()} {E_INST} {(answer['content']).strip()} ",
+                        bos=True,
+                        eos=True,
+                    )
+                    for prompt, answer in zip(
+                        dialog[::2],
+                        dialog[1::2],
+                    )
+                ],
+                [],
+            )
+            assert (
+                dialog[-1]["role"] == "user"
+            ), f"Last message must be from user, got {dialog[-1]['role']}"
+            dialog_tokens += self.tokenizer.encode(
+                f"{B_INST} {(dialog[-1]['content']).strip()} {E_INST}",
+                bos=True,
+                eos=False,
+            )
+            prompt_tokens.append(dialog_tokens)
+
+        generation_tokens, generation_logprobs = self.generate(
+            prompt_tokens=prompt_tokens,
+            max_gen_len=max_gen_len,
+            temperature=temperature,
+            top_p=top_p,
+            logprobs=logprobs,
+        )
+        if logprobs:
+            return [
+                {
+                    "generation": {
+                        "role": "assistant",
+                        "content": self.tokenizer.decode(t)
+                        if not unsafe
+                        else UNSAFE_ERROR,
+                    },
+                    "tokens": [self.tokenizer.decode(x) for x in t],
+                    "logprobs": logprobs_i,
+                }
+                for t, logprobs_i, unsafe in zip(
+                    generation_tokens, generation_logprobs, unsafe_requests
+                )
+            ]
+        return [
+            {
+                "generation": {
+                    "role": "assistant",
+                    "content": self.tokenizer.decode(t) if not unsafe else UNSAFE_ERROR,
+                }
+            }
+            for t, unsafe in zip(generation_tokens, unsafe_requests)
+        ]
+

--- a/tests/test_llama_e2e.py
+++ b/tests/test_llama_e2e.py
@@ -45,7 +45,7 @@ class LlamaE2ETest(unittest.TestCase):
     def test_original_llama2_seed(self):
         jax.config.update('jax_platform_name', 'cpu')
         x = jnp.square(2)
-        print(f"---------> {repr(x.addressable_data(0).devices())}")
+        print(f"---------> {jax.devices()}")
         torch.set_default_dtype(torch.bfloat16)
         env = self._make_env()
         model_arg = env._model_arg 
@@ -67,7 +67,7 @@ class LlamaE2ETest(unittest.TestCase):
     def test_jetstream_llama2_seed(self):
         jax.config.update('jax_platform_name', 'cpu')
         x = jnp.square(2)
-        print(f"---------> {repr(x.addressable_data(0).devices())}")
+        print(f"---------> {jax.devices()}")
 
         torch.set_default_dtype(torch.bfloat16)
         env = self._make_env()
@@ -134,7 +134,7 @@ class LlamaE2ETest(unittest.TestCase):
     def test_llama_e2e(self):
         jax.config.update('jax_platform_name', 'cpu')
         x = jnp.square(2)
-        print(f"---------> {repr(x.addressable_data(0).devices())}")
+        print(f"---------> {jax.devices()}")
 
         torch.set_default_dtype(torch.bfloat16)
         env = self._make_env()
@@ -203,7 +203,7 @@ class LlamaE2ETest(unittest.TestCase):
     def test_llama_e2e_two_addtional_tokens(self):
         jax.config.update('jax_platform_name', 'cpu')
         x = jnp.square(2)
-        print(f"---------> {repr(x.addressable_data(0).devices())}")
+        print(f"---------> {jax.devices()}")
 
         torch.set_default_dtype(torch.bfloat16)
         env = self._make_env()
@@ -271,13 +271,13 @@ class LlamaE2ETest(unittest.TestCase):
     def test_llama_e2e_four_addtional_tokens(self):
         jax.config.update('jax_platform_name', 'cpu')
         x = jnp.square(2)
-        print(f"---------> {repr(x.addressable_data(0).devices())}")
+        print(f"---------> {jax.devices()}")
 
         torch.set_default_dtype(torch.bfloat16)
         env = self._make_env()
         model_arg = env._model_arg 
         tokens = np.arange(10, dtype=np.int32)
-        tokens = np.append(tokens, [15050, 3503, 28551, 29604], axis=-1)
+        tokens = np.append(tokens, [15050, 3503, 11833, 28551], axis=-1)
         true_length = tokens.shape[-1]
         padded_tokens = np.pad(tokens, (0, 6))
         padded_tokens = jnp.array(padded_tokens)

--- a/tests/test_llama_e2e.py
+++ b/tests/test_llama_e2e.py
@@ -1,0 +1,341 @@
+import torch
+import os
+from torch.utils import _pytree as pytree
+import torch_xla2
+import jax
+import jax.numpy as jnp
+import numpy as np
+from jetstream_pt.engine import PyTorchEngine
+from jetstream_pt.third_party.llama2 import model_exportable
+from jetstream_pt.third_party.llama2.generation_original import LlamaOriginal
+from jetstream_pt import environment
+
+
+
+
+import unittest
+
+
+class LlamaE2ETest(unittest.TestCase):
+
+    def setup(self):
+        torch.set_default_dtype(torch.bfloat16)
+
+    
+
+    def _to_jax(self, tree):
+        return pytree.tree_map_only(
+            torch.Tensor,
+            torch_xla2.tensor.t2j, tree)    
+
+    def _make_env(self):
+        jax.config.update('jax_dynamic_shapes', False)
+        jax.config.update('jax_traceback_filtering', 'off')
+        env_data = environment.JetEngineEnvironmentData()
+        env_data.max_input_sequence_length = 128
+        env_data.max_input_sequence_length = 128
+        env_data.cache_sequence_length = 128
+        env_data.model_type = 'llama-2-tiny'
+        env_data.batch_size = 1
+        env = environment.JetEngineEnvironment(env_data)
+        env.apply_sharding = lambda *args, **kwargs: None  # don't shard on cpu
+        return env
+
+
+    def test_original_llama2_seed(self):
+        jax.config.update('jax_platform_name', 'cpu')
+        x = jnp.square(2)
+        print(f"---------> {repr(x.addressable_data(0).devices())}")
+        torch.set_default_dtype(torch.bfloat16)
+        env = self._make_env()
+        model_arg = env._model_arg 
+        tokens = np.arange(10, dtype=np.int32)
+        file_dir = os.path.dirname(__file__)
+        tokenizer_path = os.path.join(file_dir, '../jetstream_pt/third_party/llama2/tokenizer.model')
+        output_tokens_multiple = []
+        for i in [1, 999, 99999]:
+            llama_original = LlamaOriginal.build(tokenizer_path, model_arg, i)
+            prompt_tokens = [tokens]
+            output_tokens = llama_original.generate(prompt_tokens, 10)
+            output_tokens_multiple.append(output_tokens)
+
+        for index, output_tokens in enumerate(output_tokens_multiple): 
+            print(f"------------------- index: {index}, tokens:{output_tokens}")
+            if index > 0:
+                self.assertNotEqual(output_tokens_multiple[index], output_tokens_multiple[index - 1])
+
+    def test_jetstream_llama2_seed(self):
+        jax.config.update('jax_platform_name', 'cpu')
+        x = jnp.square(2)
+        print(f"---------> {repr(x.addressable_data(0).devices())}")
+
+        torch.set_default_dtype(torch.bfloat16)
+        env = self._make_env()
+        model_arg = env._model_arg 
+        tokens = np.arange(10, dtype=np.int32)
+        true_length = tokens.shape[-1]
+        padded_tokens = np.pad(tokens, (0, 6))
+        padded_tokens = jnp.array(padded_tokens)
+
+        seed = 1
+        max_output_length = 10
+
+        file_dir = os.path.dirname(__file__)
+        tokenizer_path = os.path.join(file_dir, '../jetstream_pt/third_party/llama2/tokenizer.model')
+
+
+        seed = 1
+        # orginal
+        llama_original = LlamaOriginal.build(tokenizer_path, model_arg, seed)
+        model_orig = llama_original.model
+
+        state_dict = dict(model_orig.state_dict())
+        state_dict['freqs_cis'] = model_orig.freqs_cis
+        params = self._to_jax(state_dict)
+
+        output_tokens_multiple = []
+        for i in [1, 2, 3]:
+            torch.manual_seed(1)
+            model_ours = model_exportable.Transformer(model_arg, env)
+            engine = PyTorchEngine(
+                pt_model=model_ours,
+                env=env
+            )
+            
+            decode_state = engine.init_decode_state()
+            slot = 0 
+            prefill_result = engine.prefill(
+                params=params, padded_tokens=padded_tokens, true_length=true_length
+            )
+
+            decode_state = engine.insert(
+                prefill_result, decode_state, slot=slot
+            )
+
+            out_tokens = []
+            while True:
+                decode_state, result_tokens = engine.generate(params, decode_state)
+                slot_data = result_tokens.get_result_at_slot(slot)
+                slot_tokens = slot_data.tokens
+                slot_lengths = slot_data.lengths
+                
+                token_id = slot_tokens[slot, 0].item()
+                out_tokens.append(token_id)
+                if slot_lengths > max_output_length:
+                    break
+
+            output_tokens_multiple.append(out_tokens)
+
+        for index, output_tokens in enumerate(output_tokens_multiple): 
+            print(f"------------------- index: {index}, tokens:{output_tokens}")
+            if index > 0:
+                self.assertEqual(output_tokens_multiple[index], output_tokens_multiple[index - 1])
+
+    def test_llama_e2e(self):
+        jax.config.update('jax_platform_name', 'cpu')
+        x = jnp.square(2)
+        print(f"---------> {repr(x.addressable_data(0).devices())}")
+
+        torch.set_default_dtype(torch.bfloat16)
+        env = self._make_env()
+        model_arg = env._model_arg 
+        tokens = np.arange(10, dtype=np.int32)
+        true_length = tokens.shape[-1]
+        padded_tokens = np.pad(tokens, (0, 6))
+        padded_tokens = jnp.array(padded_tokens)
+
+        seed = 1
+        torch.manual_seed(1)
+        max_output_length = 10
+
+        file_dir = os.path.dirname(__file__)
+        tokenizer_path = os.path.join(file_dir, '../jetstream_pt/third_party/llama2/tokenizer.model')
+
+        # orginal
+        llama_original = LlamaOriginal.build(tokenizer_path, model_arg, seed)
+        prompt_tokens = [tokens]
+        expected_output_tokens = llama_original.generate(prompt_tokens, max_output_length)
+
+
+        model_orig = llama_original.model
+
+        state_dict = dict(model_orig.state_dict())
+        state_dict['freqs_cis'] = model_orig.freqs_cis
+
+
+        model_ours = model_exportable.Transformer(model_arg, env)
+        
+        engine = PyTorchEngine(
+            pt_model=model_ours,
+            env=env
+        )
+
+        params = self._to_jax(state_dict)
+        decode_state = engine.init_decode_state()
+        slot = 0 
+
+        prefill_result = engine.prefill(
+            params=params, padded_tokens=padded_tokens, true_length=true_length
+        )
+
+        decode_state = engine.insert(
+            prefill_result, decode_state, slot=slot
+        )
+
+        out_tokens = []
+        while True:
+            decode_state, result_tokens = engine.generate(params, decode_state)
+            slot_data = result_tokens.get_result_at_slot(slot)
+            slot_tokens = slot_data.tokens
+            slot_lengths = slot_data.lengths
+            
+            token_id = slot_tokens[slot, 0].item()
+            out_tokens.append(token_id)
+            if slot_lengths > max_output_length:
+                break
+        print(f"-------------------->out_tokens:{out_tokens}")
+        print(f"-------------------->expected_output_tokens:{expected_output_tokens}")
+        # self.assertEqual(out_tokens ,expected_output_tokens)
+
+
+
+
+    def test_llama_e2e_two_addtional_tokens(self):
+        jax.config.update('jax_platform_name', 'cpu')
+        x = jnp.square(2)
+        print(f"---------> {repr(x.addressable_data(0).devices())}")
+
+        torch.set_default_dtype(torch.bfloat16)
+        env = self._make_env()
+        model_arg = env._model_arg 
+        tokens = np.arange(10, dtype=np.int32)
+        tokens = np.append(tokens, [15050, 3503], axis=-1)
+        true_length = tokens.shape[-1]
+        padded_tokens = np.pad(tokens, (0, 6))
+        padded_tokens = jnp.array(padded_tokens)
+
+        seed = 1
+        torch.manual_seed(1)
+        max_output_length = 10
+
+        file_dir = os.path.dirname(__file__)
+        tokenizer_path = os.path.join(file_dir, '../jetstream_pt/third_party/llama2/tokenizer.model')
+
+        # orginal
+        llama_original = LlamaOriginal.build(tokenizer_path, model_arg, seed)
+        prompt_tokens = [tokens]
+        expected_output_tokens = llama_original.generate(prompt_tokens, max_output_length)
+
+
+        model_orig = llama_original.model
+
+        state_dict = dict(model_orig.state_dict())
+        state_dict['freqs_cis'] = model_orig.freqs_cis
+
+
+        model_ours = model_exportable.Transformer(model_arg, env)
+        
+        engine = PyTorchEngine(
+            pt_model=model_ours,
+            env=env
+        )
+
+        params = self._to_jax(state_dict)
+        decode_state = engine.init_decode_state()
+        slot = 0 
+
+        prefill_result = engine.prefill(
+            params=params, padded_tokens=padded_tokens, true_length=true_length
+        )
+
+        decode_state = engine.insert(
+            prefill_result, decode_state, slot=slot
+        )
+
+        out_tokens = []
+        while True:
+            decode_state, result_tokens = engine.generate(params, decode_state)
+            slot_data = result_tokens.get_result_at_slot(slot)
+            slot_tokens = slot_data.tokens
+            slot_lengths = slot_data.lengths
+            
+            token_id = slot_tokens[slot, 0].item()
+            out_tokens.append(token_id)
+            if slot_lengths > max_output_length:
+                break
+        print(f"-------------------->out_tokens:{out_tokens}")
+        print(f"-------------------->expected_output_tokens:{expected_output_tokens}")
+        # self.assertEqual(out_tokens ,expected_output_tokens)
+
+
+    def test_llama_e2e_four_addtional_tokens(self):
+        jax.config.update('jax_platform_name', 'cpu')
+        x = jnp.square(2)
+        print(f"---------> {repr(x.addressable_data(0).devices())}")
+
+        torch.set_default_dtype(torch.bfloat16)
+        env = self._make_env()
+        model_arg = env._model_arg 
+        tokens = np.arange(10, dtype=np.int32)
+        tokens = np.append(tokens, [15050, 3503, 28551, 29604], axis=-1)
+        true_length = tokens.shape[-1]
+        padded_tokens = np.pad(tokens, (0, 6))
+        padded_tokens = jnp.array(padded_tokens)
+
+        seed = 1
+        torch.manual_seed(1)
+        max_output_length = 10
+
+        file_dir = os.path.dirname(__file__)
+        tokenizer_path = os.path.join(file_dir, '../jetstream_pt/third_party/llama2/tokenizer.model')
+
+        # orginal
+        llama_original = LlamaOriginal.build(tokenizer_path, model_arg, seed)
+        prompt_tokens = [tokens]
+        expected_output_tokens = llama_original.generate(prompt_tokens, max_output_length)
+
+
+        model_orig = llama_original.model
+
+        state_dict = dict(model_orig.state_dict())
+        state_dict['freqs_cis'] = model_orig.freqs_cis
+
+
+        model_ours = model_exportable.Transformer(model_arg, env)
+        
+        engine = PyTorchEngine(
+            pt_model=model_ours,
+            env=env
+        )
+
+        params = self._to_jax(state_dict)
+        decode_state = engine.init_decode_state()
+        slot = 0 
+
+        prefill_result = engine.prefill(
+            params=params, padded_tokens=padded_tokens, true_length=true_length
+        )
+
+        decode_state = engine.insert(
+            prefill_result, decode_state, slot=slot
+        )
+
+        out_tokens = []
+        while True:
+            decode_state, result_tokens = engine.generate(params, decode_state)
+            slot_data = result_tokens.get_result_at_slot(slot)
+            slot_tokens = slot_data.tokens
+            slot_lengths = slot_data.lengths
+            
+            token_id = slot_tokens[slot, 0].item()
+            out_tokens.append(token_id)
+            if slot_lengths > max_output_length:
+                break
+        print(f"-------------------->out_tokens:{out_tokens}")
+        print(f"-------------------->expected_output_tokens:{expected_output_tokens}")
+        # self.assertEqual(out_tokens ,expected_output_tokens)        
+
+if __name__ == '__main__':
+    unittest.main()
+
+


### PR DESCRIPTION
The purpose of this PR is testing the E2E accuracy between Jetstream engine inference and original llama inference. Below are tests:

- test_llama_e2e.  original llama inference 10 steps decode **vs** jetstream engine 10 steps
- test_original_llama2_seed.   original llama inference 10 steps with different seed
- test_jetstream_llama2_seed. jetstream engine 10 with different seed
- test_llama_e2e_two_addtional_tokens.  Same prefix as test_llama_e2e, add two additional tokens in prompts.  
-  test_llama_e2e_four_addtional_tokens.  Same prefix as test_llama_e2e, add four additional tokens in prompts.  