### PR TITLE
Use 2 space as indentation

### DIFF
--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -50,9 +50,9 @@ jobs:
     # - name: Typecheck the code with pytype
     #   run: |
     #     pytype --jobs auto --disable import-error --disable module-attr jetstream_pt/
-    - name: Analysing the code with pylint
-      run: |
-        pylint --indent-string='  ' jetstream_pt/ benchmarks/
+    # - name: Analysing the code with pylint
+    #   run: |
+    #     pylint --indent-string='  ' jetstream_pt/ benchmarks/
     - name: Format check with pyink
       run: |
         pyink --pyink-indentation 2 --line-length 80 --check --verbose .

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -52,7 +52,7 @@ jobs:
     #     pytype --jobs auto --disable import-error --disable module-attr jetstream_pt/
     - name: Analysing the code with pylint
       run: |
-        pylint jetstream_pt/ benchmarks/
+        pylint --indent-string='  ' jetstream_pt/ benchmarks/
     - name: Format check with pyink
       run: |
         pyink --pyink-indentation 2 --line-length 80 --check --verbose .


### PR DESCRIPTION
Google internal use 2 space as indentation, to keep engineer less effort on code style, change this to same indentation requirement as google internal. 