### PR TITLE
Cleanup test_jax_torch

### DIFF
--- a/tests/test_jax_torch.py
+++ b/tests/test_jax_torch.py
@@ -1,14 +1,15 @@
+import unittest
 import torch
 import torch_xla2
 import jax
 import jax.numpy as jnp
 
-import unittest
-
 
 class JaxTorchTest(unittest.TestCase):
+  """Unit test compare Jax and Torch gap with float precision"""
 
   def test_matmul_bfloat16_xla2(self):
+    """test jax vs torch matmul diff with bfloat16 on cpu"""
     jax.config.update("jax_platform_name", "cpu")
     torch.set_default_dtype(torch.bfloat16)
     r = c = 1000
@@ -28,6 +29,7 @@ class JaxTorchTest(unittest.TestCase):
     self.assertTrue(torch.allclose(target_result, result, atol=1))
 
   def test_matmul_bfloat32(self):
+    """test jax vs torch matmul diff with bfloat32 on cpu"""
     jax.config.update("jax_platform_name", "cpu")
     torch.set_default_dtype(torch.float32)
     r = c = 1000


### PR DESCRIPTION
After this PR:
Your code has been **rated at 10.00/10**

Before this PR:
Your code has been **rated at 8.95/10**
************* Module tests.test_jax_torch
test_jax_torch.py:9:0: C0115: Missing class docstring (missing-class-docstring)
test_jax_torch.py:11:2: C0116: Missing function or method docstring (missing-function-docstring)
test_jax_torch.py:30:2: C0116: Missing function or method docstring (missing-function-docstring)
test_jax_torch.py:6:0: C0411: standard import "unittest" should be placed before third party imports "torch", "torch_xla2", "jax", "jax.numpy" (wrong-import-order)

-----------------------------------
