### PR TITLE
Fix test quantization lint check

### DIFF
--- a/tests/test_quantization.py
+++ b/tests/test_quantization.py
@@ -12,22 +12,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import jax
 import unittest
-from jetstream_pt import cache_manager
-from jetstream_pt import quantize
+import jax
+import jax.numpy as jnp
 import torch
 import torch_xla2
-import jax.numpy as jnp
+
+from jetstream_pt import cache_manager
+
 
 
 class QuantizationTest(unittest.TestCase):
+  """test kv cache quantization"""
 
   def _xla_tensor(self, shape):
     res = torch.randn(shape, dtype=torch.bfloat16)
     return torch_xla2.tensor.move_to_device(res)
 
   def test_kv_cache(self):
+    """test kv cache quantization"""
     cache_shape = (3, 2, 100, 2)  # bs, num heads, seqlen, dim
     with jax.default_device(jax.devices("cpu")[0]):
       cache = cache_manager.Int8KVCacheGenerate.empty(cache_shape, None, False)


### PR DESCRIPTION
After this PR:
Your code has been **rated at 10.00/10**

Before this PR:
Your code has been **rated at 8.00/10**
************* Module tests.test_quantization
test_quantization.py:24:0: C0115: Missing class docstring (missing-class-docstring)
test_quantization.py:30:2: C0116: Missing function or method docstring (missing-function-docstring)
test_quantization.py:16:0: C0411: standard import "unittest" should be placed before third party import "jax" (wrong-import-order)
test_quantization.py:21:0: C0412: Imports from package jax are not grouped (ungrouped-imports)
test_quantization.py:18:0: W0611: Unused quantize imported from jetstream_pt (unused-import)

-----------------------------------
