### PR TITLE
Comment broken function to unblock interactive run after JetStream api change

### DIFF
--- a/run_interactive.py
+++ b/run_interactive.py
@@ -148,11 +148,11 @@ def main(argv):
         break
 
       sampled_tokens_list.append(token_id)
-      output = token_utils.mix_decode(vocab, token_id)
-      print(Fore.GREEN + output, end="", flush=True)
+    #   output = token_utils.mix_decode(vocab, token_id)
+    #   print(Fore.GREEN + output, end="", flush=True)
 
-    print(Style.RESET_ALL + "\n")
-    print("---- Streaming decode finished.")
+    # print(Style.RESET_ALL + "\n")
+    # print("---- Streaming decode finished.")
 
     print("---- All output tokens.")
     print(sampled_tokens_list)


### PR DESCRIPTION
JetStream PR 40 removed  mix_decode 
 function (https://github.com/google/JetStream/commit/a0df320cb4a720bf123e2579973034628dbe3344#diff-1f6a127e88897ae4bd1191a2b3609a1507a9e667fbc22dda89f67b26653e99eb). 

Pytorch engine is depending on mix_decode and use it to do stream decode. Comment this part of code to unblock pytorch engine interactive run. 