### PR TITLE
Fix sharding config file name bug

### DIFF
--- a/jetstream_pt/engine.py
+++ b/jetstream_pt/engine.py
@@ -712,7 +712,9 @@ def create_pytorch_engine(
 
   if not sharding_config:
     sharding_file_name = "llama" if model_name.startswith("llama") else "gemma"
-    sharding_config = os.path.join("default_shardings", sharding_file_name + ".yaml")
+    sharding_config = os.path.join(
+        "default_shardings", sharding_file_name + ".yaml"
+    )
 
   env_data = JetEngineEnvironmentData(
       tokenizer_path=tokenizer_path,

--- a/jetstream_pt/engine.py
+++ b/jetstream_pt/engine.py
@@ -711,7 +711,8 @@ def create_pytorch_engine(
   pt_model = None
 
   if not sharding_config:
-    sharding_config = os.path.join("default_shardings", model_name + ".yaml")
+    sharding_file_name = "llama" if model_name.startswith("llama") else "gemma"
+    sharding_config = os.path.join("default_shardings", sharding_file_name + ".yaml")
 
   env_data = JetEngineEnvironmentData(
       tokenizer_path=tokenizer_path,

--- a/run_server.py
+++ b/run_server.py
@@ -105,10 +105,6 @@ def main(argv: Sequence[str]):
   devices = server_lib.get_devices()
   print(f"devices: {devices}")
   sharding_config_path = _SHARDING_CONFIG.value
-  if not sharding_config_path:
-    sharding_config_path = os.path.join(
-        "default_shardings", _MODEL_NAME.value + ".yaml"
-    )
   engine = jetstream_pt.create_pytorch_engine(
       devices=devices,
       tokenizer_path=_TOKENIZER_PATH.value,


### PR DESCRIPTION
Fix sharding config file name bug. Two fixed:

1. Current code uses llama2 or llama3 as file name, but the sharding yaml file name is llama. 
2. Engine has logic to handle none sharding_config, removed the duplicated logic in run server 