### PR TITLE
Fix ray conflict changes 

### DIFF
--- a/jetstream_pt/engine.py
+++ b/jetstream_pt/engine.py
@@ -179,7 +179,7 @@ class PyTorchEngine(engine_api.Engine):
     )
     paramst, argst = torchjax.to_torch((weights, args))
     with self._lock:
-      with torchjax.jax_mode:
+      with torch_xla2.default_env():
         # The mode is needed so that tensors created inside of
         # the model (such as via torch.ones etc) also have the right type
         res = torch.func.functional_call(self.pt_model, paramst, argst)
@@ -210,7 +210,7 @@ class PyTorchEngine(engine_api.Engine):
 
     paramst, argst = torchjax.to_torch((weights, args))
     with self._lock:
-      with torchjax.jax_mode:
+      with torch_xla2.default_env():
         res = torch.func.functional_call(self.pt_model, paramst, argst)[0]
     caches_res = [c.state() for c in caches]
     return torchjax.from_torch((res, caches_res))

--- a/jetstream_pt/ray_worker.py
+++ b/jetstream_pt/ray_worker.py
@@ -166,7 +166,7 @@ class PyTorchRayWorker:
         bf16_enable=bf16_enable,
         sharding_config_path=sharding_config,
     )
-    
+
     if model_name.startswith("llama"):
 
       args = model_args.get_model_args(

--- a/jetstream_pt/ray_worker.py
+++ b/jetstream_pt/ray_worker.py
@@ -166,8 +166,7 @@ class PyTorchRayWorker:
         bf16_enable=bf16_enable,
         sharding_config_path=sharding_config,
     )
-    env = JetEngineEnvironment(env_data)
-
+    
     if model_name.startswith("llama"):
 
       args = model_args.get_model_args(
@@ -353,7 +352,7 @@ class PyTorchRayWorker:
     args = (tokens, input_pos, caches_obj, mask)
     paramst, argst = torchjax.to_torch((weights, args))
     with self._lock:
-      with torchjax.jax_mode():
+      with torch_xla2.default_env():
         res = torch.func.functional_call(self.pt_model, paramst, argst)
       updated_caches = [c.state() for c in caches_obj]
     scales = []
@@ -396,7 +395,7 @@ class PyTorchRayWorker:
 
     paramst, argst = torchjax.to_torch((weights, args))
     with self._lock:
-      with torchjax.jax_mode:
+      with torch_xla2.default_env():
         res = torch.func.functional_call(self.pt_model, paramst, argst)[0]
     caches_res = [c.state() for c in caches]
     return torchjax.from_torch((res, caches_res))

--- a/jetstream_pt/torchjax.py
+++ b/jetstream_pt/torchjax.py
@@ -14,17 +14,15 @@ It serves 2 purposes:
 import torch_xla2
 import torch_xla2.interop
 
-jax_mode = torch_xla2.default_env()
-
 call_jax = torch_xla2.interop.call_jax
 call_torch = torch_xla2.interop.call_torch
 
 
 def to_torch(tensors):
   """Wrap a jax Array into XLATensor."""
-  return jax_mode.j2t_iso(tensors)
+  return torch_xla2.default_env().j2t_iso(tensors)
 
 
 def from_torch(tensors):
   """Unwrap a XLATensor into jax Array."""
-  return jax_mode.t2j_iso(tensors)
+  return torch_xla2.default_env().t2j_iso(tensors)

--- a/run_interactive_multiple_host.py
+++ b/run_interactive_multiple_host.py
@@ -54,7 +54,7 @@ def create_engine():
 # pylint: disable-next=all
 def main(argv):
 
-  engine = create_engine_from_config_flags()
+  engine = create_engine()
 
   start = time.perf_counter()
   engine.load_params()
@@ -99,6 +99,7 @@ def main(argv):
     while True:
       # pylint: disable-next=all
       decode_state, result_tokens = engine.generate(None, decode_state)
+      result_tokens = result_tokens.convert_to_numpy()
 
       slot_data = result_tokens.get_result_at_slot(slot)
       slot_tokens = slot_data.tokens

--- a/run_interactive_multiple_host.py
+++ b/run_interactive_multiple_host.py
@@ -43,8 +43,6 @@ def create_engine():
       quantize_kv=FLAGS.quantize_kv_cache,
       max_cache_length=FLAGS.max_cache_length,
       sharding_config=FLAGS.sharding_config,
-      shard_on_batch=FLAGS.shard_on_batch,
-      ragged_mha=FLAGS.ragged_mha,
   )
 
   print("Initialize engine", time.perf_counter() - start)

--- a/tests/test_quantization.py
+++ b/tests/test_quantization.py
@@ -237,7 +237,7 @@ class QuantizationTest(unittest.TestCase):
     )
     def f(layer, weights, args):
       paramst, argst = torchjax.to_torch((weights, args))
-      with torchjax.jax_mode:
+      with torch_xla2.default_env():
         res = torch.func.functional_call(layer, paramst, argst)
       return torchjax.from_torch(res)
 


### PR DESCRIPTION
This PR add below changes:

1: move torch_xla2.default_env() to function. jax_mode = torch_xla2.default_env() block jax multiple controller in init state
2: ray engine create is different than default run server one, it will have prefill and decode engines later 
3: removed duplciated JetEngineEnvironment 
4: Not support shard_on_batch and ragged attention in ray multiple for now