### PR TITLE
Update run_server.py. metrics_server_config is not supported in JetStream[8128c8a] yet

### DIFF
--- a/run_server.py
+++ b/run_server.py
@@ -62,7 +62,7 @@ def main(argv: Sequence[str]):
       port=FLAGS.port,
       config=server_config,
       devices=devices,
-      metrics_server_config=metrics_server_config,
+      #metrics_server_config=metrics_server_config,
   )
   print("Started jetstream_server....")
   jetstream_server.wait_for_termination()


### PR DESCRIPTION
[8128c8a](https://github.com/google/JetStream/tree/8128c8a59f859e7691726180b7953e92c6ad4b2b)