### PR TITLE
Integrate disaggregated serving with JetStream

### DIFF
--- a/jetstream_pt/ray_engine.py
+++ b/jetstream_pt/ray_engine.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-from typing import Any, Iterable, Optional, Union
+from typing import Any, Iterable, Optional, Union, Tuple, List
 
 import numpy as np
 import ray
@@ -180,7 +180,7 @@ def create_pytorch_ray_engine(
     decode_pod_slice_name: str = None,
     enable_jax_profiler: bool = False,
     jax_profiler_port: int = 9999,
-) -> Any:
+) -> Union[PyTorchRayEngine, Tuple[List[PyTorchRayEngine], List[PyTorchRayEngine]]]:
 
   # Return tuple as reponse: issues/107
   supported_models = ["llama-2", "llama-3", "gemma"]
@@ -254,4 +254,4 @@ def create_pytorch_ray_engine(
       is_disaggregated=is_disaggregated,
       pod_slice_name=decode_pod_slice_name,
   )
-  return (prefill_engine, decode_engine)
+  return ([prefill_engine], [decode_engine])

--- a/jetstream_pt/ray_engine.py
+++ b/jetstream_pt/ray_engine.py
@@ -180,7 +180,9 @@ def create_pytorch_ray_engine(
     decode_pod_slice_name: str = None,
     enable_jax_profiler: bool = False,
     jax_profiler_port: int = 9999,
-) -> Union[PyTorchRayEngine, Tuple[List[PyTorchRayEngine], List[PyTorchRayEngine]]]:
+) -> Union[
+    PyTorchRayEngine, Tuple[List[PyTorchRayEngine], List[PyTorchRayEngine]]
+]:
 
   # Return tuple as reponse: issues/107
   supported_models = ["llama-2", "llama-3", "gemma"]

--- a/run_interactive_disaggregated.py
+++ b/run_interactive_disaggregated.py
@@ -94,7 +94,7 @@ def create_disaggregated_engines():
   os.environ["TF_CPP_MIN_LOG_LEVEL"] = "0"
 
   start = time.perf_counter()
-  prefill_engine, decode_engine = ray_engine.create_pytorch_ray_engine(
+  prefill_engine_list, decode_engine_list = ray_engine.create_pytorch_ray_engine(
       model_name=_MODEL_NAME.value,
       tokenizer_path=_TOKENIZER_PATH.value,
       ckpt_path=_CKPT_PATH.value,
@@ -112,7 +112,7 @@ def create_disaggregated_engines():
   )
 
   print("Initialize engine", time.perf_counter() - start)
-  return (prefill_engine, decode_engine)
+  return (prefill_engine_list[0], decode_engine_list[0])
 
 
 # pylint: disable-next=all

--- a/run_interactive_disaggregated.py
+++ b/run_interactive_disaggregated.py
@@ -94,21 +94,23 @@ def create_disaggregated_engines():
   os.environ["TF_CPP_MIN_LOG_LEVEL"] = "0"
 
   start = time.perf_counter()
-  prefill_engine_list, decode_engine_list = ray_engine.create_pytorch_ray_engine(
-      model_name=_MODEL_NAME.value,
-      tokenizer_path=_TOKENIZER_PATH.value,
-      ckpt_path=_CKPT_PATH.value,
-      bf16_enable=True,
-      param_size=_SIZE.value,
-      context_length=_CONTEXT_LENGTH.value,
-      batch_size=_BATCH_SIZE.value,
-      quantize_weights=_QUANTIZE_WEIGHTS.value,
-      quantize_kv=_QUANTIZE_KV_CACHE.value,
-      max_cache_length=_MAX_CACHE_LENGTH.value,
-      sharding_config=_SHARDING_CONFIG.value,
-      is_disaggregated=_IS_DISAGGREGATED.value,
-      num_hosts=_NUM_HOSTS.value,
-      decode_pod_slice_name=_DECODE_POD_SLICE_NAME.value,
+  prefill_engine_list, decode_engine_list = (
+      ray_engine.create_pytorch_ray_engine(
+          model_name=_MODEL_NAME.value,
+          tokenizer_path=_TOKENIZER_PATH.value,
+          ckpt_path=_CKPT_PATH.value,
+          bf16_enable=True,
+          param_size=_SIZE.value,
+          context_length=_CONTEXT_LENGTH.value,
+          batch_size=_BATCH_SIZE.value,
+          quantize_weights=_QUANTIZE_WEIGHTS.value,
+          quantize_kv=_QUANTIZE_KV_CACHE.value,
+          max_cache_length=_MAX_CACHE_LENGTH.value,
+          sharding_config=_SHARDING_CONFIG.value,
+          is_disaggregated=_IS_DISAGGREGATED.value,
+          num_hosts=_NUM_HOSTS.value,
+          decode_pod_slice_name=_DECODE_POD_SLICE_NAME.value,
+      )
   )
 
   print("Initialize engine", time.perf_counter() - start)

--- a/run_server_with_ray.py
+++ b/run_server_with_ray.py
@@ -117,11 +117,13 @@ def main(argv: Sequence[str]):
 
   if FLAGS.is_disaggregated:
     prefill_engine_list, decode_engine_list = create_disaggregated_engine()
+    chips = int(len(devices)/2)
     server_config = ServerConfig(
-      prefill_slices=(f"tpu={len(devices)}",),
+      prefill_slices=(f"tpu={chips}",),
       prefill_engine_create_fns=(lambda a: prefill_engine_list[0],),
-      generate_slices=(f"tpu={len(devices)}",),
+      generate_slices=(f"tpu={chips}",),
       generate_engine_create_fns=(lambda a: decode_engine_list[0],),
+      is_ray_backend=True
     )
     
   else:


### PR DESCRIPTION
Integrate disaggregated serving with JetStream. Below are highlight of changes:

1. Return tuple list of prefill engine and decode engine when disaggregated serving enabled, otherwise return a interleave engine
2. Hard code the chips for engine and chips per host now, will change it in near future  
