### PR TITLE
prototyping better UX

### DIFF
--- a/convert_checkpoints.py
+++ b/convert_checkpoints.py
@@ -357,9 +357,6 @@ def _load_from_local(input_ckpt_dir: epath.Path):
   if not _FROM_HF.value:
     return _load_orig_llama_weight(input_ckpt_dir)
   else:
-    assert (
-        not FLAGS.quantize_weights
-    ), "Quantization not supported for HF checkpoint."
     return _load_hf_llama_weight(input_ckpt_dir)
 
 

--- a/install_everything.sh
+++ b/install_everything.sh
@@ -27,6 +27,7 @@ pip show torch_xla2 && pip uninstall -y torch_xla2
 pip install flax
 pip install tensorflow-text
 pip install tensorflow
+pip install huggingface_hub
 
 pip install ray[default]==2.22.0
 # torch cpu

--- a/jetstream_pt/cli.py
+++ b/jetstream_pt/cli.py
@@ -1,0 +1,131 @@
+import sys
+
+# import torch_xla2 first!
+import torch_xla2  # pylint: disable
+import jax
+from absl import app, flags
+from jetstream.core import server_lib
+from jetstream.core.config_lib import ServerConfig, MetricsServerConfig
+import torch
+
+from jetstream_pt import fetch_models
+from jetstream_pt import environment, engine, quantize_model, torchjax
+from jetstream_pt import config
+
+
+FLAGS = flags.FLAGS
+
+flags.DEFINE_string("model_id", "", "")
+flags.DEFINE_integer("override_batch_size", 32, "The batch size")
+flags.DEFINE_integer("max_input_length", 1024, "The batch size")
+flags.DEFINE_integer("max_output_length", 1024, "The batch size")
+flags.DEFINE_string("data_type", "bfloat16", "")
+flags.DEFINE_integer("port", 9000, "port to listen on")
+flags.DEFINE_integer("threads", 64, "number of worker threads in thread pool")
+
+
+def shard_weights(env, weights, weight_shardings):
+  """Shard weights according to weight_shardings"""
+  for k, v in weight_shardings.items():
+    print("SHARDING", k, v)
+  sharded = {}
+  for key, val in weights.items():
+    sharding = env.sharding_by_axis(weight_shardings.get(key, -1))
+    with jax.default_device(jax.devices("cpu")[0]):
+      arr = torch_xla2.tensor.t2j(val)
+    arr = jax.device_put(arr, sharding)
+    sharded[key] = torchjax.to_torch(arr)
+  return sharded
+
+
+def create_engine(devices):
+  """Create Pytorch engine from flags"""
+  torch.set_default_dtype(torch.bfloat16)
+  env_data = fetch_models.construct_env_data_from_model_id(
+      FLAGS.model_id,
+      FLAGS.override_batch_size,
+      FLAGS.max_input_length,
+      FLAGS.max_output_length,
+      FLAGS.data_type == "int8",
+  )
+  env = environment.JetEngineEnvironment(env_data)
+  model = fetch_models.instantiate_model_from_repo_id(FLAGS.model_id, env)
+
+  weight_shardings = model.get_sharding_annotations()
+  sharded_weights = shard_weights(env, model.state_dict(), weight_shardings)
+
+  quant_config = config.create_quantization_config_from_flags()
+  if quant_config.enable_weight_quantization:
+    model.load_state_dict(sharded_weights, assign=True, strict=False)
+    quantize_model.quantize_model(model, quant_config)
+    sharded_weights = model.state_dict()
+
+  return engine.PyTorchEngine(
+      pt_model=model,
+      env=env,
+      weights=torchjax.from_torch_with_copy(sharded_weights),
+  )
+
+
+def list_model():
+  """Print list of models."""
+  for model_id in fetch_models.model_id_to_class:
+    print(model_id)
+
+
+def serve():
+  """Run gRPC server."""
+  if FLAGS.model_id == "":
+    print("Please specify model_id with --model_id")
+    print("valid model ids are:")
+    list_model()
+    sys.exit(1)
+  devices = server_lib.get_devices()
+  print(f"devices: {devices}")
+
+  server_config = ServerConfig(
+      interleaved_slices=(f"tpu={len(jax.devices())}",),
+      interleaved_engine_create_fns=[create_engine],
+  )
+  print(f"server_config: {server_config}")
+
+  metrics_server_config: MetricsServerConfig | None = None
+
+  # We separate credential from run so that we can unit test it with local credentials.
+  # We would like to add grpc credentials for OSS.
+  jetstream_server = server_lib.run(
+      threads=FLAGS.threads,
+      port=FLAGS.port,
+      config=server_config,
+      devices=devices,
+      metrics_server_config=metrics_server_config,
+  )
+  print("Started jetstream_server....")
+  jetstream_server.wait_for_termination()
+
+
+def interactive():
+  """Run interactive"""
+  raise RuntimeError("Not implemented")
+
+
+def main(argv):
+  """Entry point"""
+  if len(argv) < 2:
+    print("Invalid arguments. please specify 'list' or 'serve'")
+
+  if argv[1] == "list":
+    list_model()
+    return
+
+  if argv[1] == "serve":
+    serve()
+    return
+
+  if argv[1] == "interative":
+    list_model()
+    return
+
+
+if __name__ == "__main__":
+  app.run(main)

--- a/jetstream_pt/engine.py
+++ b/jetstream_pt/engine.py
@@ -688,27 +688,18 @@ class PyTorchEngine(engine_api.Engine):
 
     return pytree.tree_map_only(torch.Tensor, make_array, model_args_meta)
 
-  def _load_from_safetensors(self, dir_path):
+  def _load_from_safetensors(self, path):
     weights = {}
-    if os.path.isdir(dir_path):
-      pathes = glob.glob(os.path.join(dir_path, "*.safetensors"))
-    else:
-      # dir_path is a single file
-      pathes = [dir_path]
-    for path in pathes:
-      with safe_open(path, framework="flax", device="cpu") as f:
-        for key in f.keys():
-          weights[key] = f.get_tensor(key).astype(jnp.dtype("bfloat16"))
-
-    # optionally change the names from hf names -> orig name
-    updated = {}
-    weight_map = self.pt_model.get_hf_names_to_real_name()
-    for key, val in weights.items():
-      if key in weight_map:
-        updated[weight_map[key]] = val
-
-    updated["freqs_cis"] = torch_xla2.tensor.t2j(self.pt_model.freqs_cis)
-    return updated
+    with safe_open(path, framework="flax", device="cpu") as f:
+      for key, model_weights in self.pt_model.state_dict().items():
+        if key == "freqs_cis":
+          continue
+        weights[key] = f.get_tensor(key)
+        assert tuple(model_weights.shape) == tuple(
+            weights[key].shape
+        ), f"key: {key} error: {model_weights.shape} != {weights[key].shape}"
+    weights["freqs_cis"] = torch_xla2.tensor.t2j(self.pt_model.freqs_cis)
+    return weights
 
   def _load_from_state_dict(self, path):
     state_dict = torch.load(path, map_location=torch.device("cpu"))

--- a/jetstream_pt/environment.py
+++ b/jetstream_pt/environment.py
@@ -12,18 +12,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Tuple, Dict
-
 import dataclasses
-import yaml
+from typing import Tuple
 
+from absl import flags
 import jax
 import jax.sharding as jsharding
 from jax.experimental import mesh_utils
 import torch_xla2
+import yaml
 
 
 from jetstream_pt import cache_manager
+
+
+FLAGS = flags.FLAGS
+flags.DEFINE_integer(
+    "internal_starting_position", 512, "Starting position in kv cache"
+)
 
 
 @dataclasses.dataclass
@@ -36,7 +42,6 @@ class QuantizationConfig:
   is_symmetric_weight: bool = True
 
   enable_activation_quantization: bool = False
-
   enable_kv_quantization: bool = False
 
 
@@ -74,11 +79,6 @@ class JetEngineEnvironmentData:
   # This is the axis to shard among the number of available devices
   # This string must be one of the values of attention_kv_axis_names above
   kv_cache_shard_axis: str = "num_attn_heads"
-
-  # Override sharding axis of a weight by name
-  experimental_sharding_axis_override: Dict[str, int] = dataclasses.field(
-      default_factory=dict
-  )
 
   # QKV fusion has negative performance on TPU, slicing takes longer
   qkv_fusion: bool = False

--- a/jetstream_pt/environment.py
+++ b/jetstream_pt/environment.py
@@ -15,7 +15,6 @@
 import dataclasses
 from typing import Tuple
 
-from absl import flags
 import jax
 import jax.sharding as jsharding
 from jax.experimental import mesh_utils
@@ -24,12 +23,6 @@ import yaml
 
 
 from jetstream_pt import cache_manager
-
-
-FLAGS = flags.FLAGS
-flags.DEFINE_integer(
-    "internal_starting_position", 512, "Starting position in kv cache"
-)
 
 
 @dataclasses.dataclass

--- a/jetstream_pt/fetch_models.py
+++ b/jetstream_pt/fetch_models.py
@@ -29,22 +29,6 @@ flags.DEFINE_integer(
 )
 
 
-llama_model_ids = [
-    "meta-llama/Llama-2-7b-chat-hf",
-    "meta-llama/Llama-2-13b-chat-hf",
-    "meta-llama/Llama-2-7b-hf",
-    "meta-llama/Llama-2-13b-hf",
-    "meta-llama/Llama-3-8B",
-    "meta-llama/Llama-3-8B-Instruct",
-    "google/gemma-2b",
-    "google/gemma-2b-it",
-    "google/gemma-7b",
-    "google/gemma-7b-it",
-    "mistralai/Mixtral-8x7B-v0.1",
-    "mistralai/Mixtral-8x7B-Instruct-v0.1",
-]
-
-
 @dataclasses.dataclass
 class ModelInfo:
   """Model information."""

--- a/jetstream_pt/fetch_models.py
+++ b/jetstream_pt/fetch_models.py
@@ -1,0 +1,216 @@
+import dataclasses
+import glob
+import os
+from typing import Optional
+from requests.exceptions import HTTPError
+from huggingface_hub import snapshot_download
+from absl import flags
+import torch
+from safetensors import safe_open
+from jetstream_pt.environment import (
+    JetEngineEnvironmentData,
+    QuantizationConfig,
+)
+from jetstream_pt.third_party.llama import model_exportable as llama_model
+
+FLAGS = flags.FLAGS
+
+flags.DEFINE_string(
+    "working_dir",
+    "checkpoints",
+    "Directory to store downloaded/converted weights",
+)
+flags.DEFINE_string("hf_token", "", "huggingface token")
+
+flags.DEFINE_integer(
+    "override_max_cache_length",
+    -1,
+    "Size of cache, defaults to input + output length",
+)
+
+
+llama_model_ids = [
+    "meta-llama/Llama-2-7b-chat-hf",
+    "meta-llama/Llama-2-13b-chat-hf",
+    "meta-llama/Llama-2-7b-hf",
+    "meta-llama/Llama-2-13b-hf",
+    "meta-llama/Llama-3-8B",
+    "meta-llama/Llama-3-8B-Instruct",
+    "google/gemma-2b",
+    "google/gemma-2b-it",
+    "google/gemma-7b",
+    "google/gemma-7b-it",
+    "mistralai/Mixtral-8x7B-v0.1",
+    "mistralai/Mixtral-8x7B-Instruct-v0.1",
+]
+
+
+@dataclasses.dataclass
+class ModelInfo:
+  """Model information."""
+
+  model_class: torch.nn.Module
+  # information needed to allocate cache
+  num_layers: int
+  num_heads: int
+  head_dim: int
+
+
+_llama2_7 = ModelInfo(llama_model.Transformer, 32, 32, 128)
+_llama2_13 = ModelInfo(llama_model.Transformer, 40, 40, 128)
+_llama2_70 = ModelInfo(llama_model.Transformer, 80, 8, 128)
+_llama3_8 = ModelInfo(llama_model.Transformer, 32, 8, 128)
+
+
+model_id_to_class = {
+    "meta-llama/Llama-2-7b-chat-hf": _llama2_7,
+    "meta-llama/Llama-2-7b-hf": _llama2_7,
+    "meta-llama/Llama-2-13b-chat-hf": _llama2_13,
+    "meta-llama/Llama-2-13b-hf": _llama2_13,
+    "meta-llama/Meta-Llama-3-8B": _llama3_8,
+    "meta-llama/Meta-Llama-3-8B-Instruct": _llama3_8,
+    "google/gemma-2b": None,
+    "google/gemma-2b-it": None,
+    "google/gemma-7b": None,
+    "google/gemma-7b-it": None,
+    "mistralai/Mixtral-8x7B-v0.1": None,
+    "mistralai/Mixtral-8x7B-Instruct-v0.1": None,
+}
+
+
+def _model_dir(repo_id):
+  """Model dir structure:
+
+  working_dir/
+    repo_id/
+      hf_original/
+      converted_bfloat/
+      converted_int8/
+  """
+  return os.path.join(FLAGS.working_dir, repo_id)
+
+
+def _hf_dir(repo_id):
+  """Dir to hf repo"""
+  return os.path.join(_model_dir(repo_id), "hf_original")
+
+
+def _int_dir(repo_id):
+  return os.path.join(_model_dir(repo_id), "converted_int8")
+
+
+def construct_env_data_from_model_id(
+    repo_id,
+    batch_size,
+    input_length,
+    output_length,
+    quantize,
+):
+  """Create Environment from model id and options"""
+  tokenizer_path = os.path.join(_hf_dir(repo_id), "tokenizer.model")
+  if quantize:
+    checkpoint_path = _int_dir(repo_id)
+    checkpoint_format = "safetensors"
+  else:
+    checkpoint_path = _hf_dir(repo_id)
+    checkpoint_format = "safetensors"
+
+  shard_on_batch = False
+
+  max_cache_length = (
+      FLAGS.override_max_cache_length
+      if FLAGS.override_max_cache_length > 0
+      else input_length + output_length
+  )
+
+  env_data = JetEngineEnvironmentData(
+      tokenizer_path=tokenizer_path,
+      checkpoint_path=checkpoint_path,
+      checkpoint_format=checkpoint_format,
+      batch_size=batch_size,
+      max_decode_length=output_length,
+      max_input_sequence_length=input_length,
+      quant_config=QuantizationConfig(),
+      cache_sequence_length=max_cache_length,
+      bf16_enable=True,
+      sharding_config_path="",
+      shard_on_batch=shard_on_batch,
+  )
+  model_info = model_id_to_class.get(repo_id)
+  env_data.cache_shape = (
+      batch_size,
+      model_info.num_heads,
+      max_cache_length,
+      model_info.head_dim,
+  )
+  env_data.num_layers = model_info.num_layers
+  return env_data
+
+
+def _load_weights(directory):
+  safetensors_files = glob.glob(os.path.join(directory, "*.safetensors"))
+  state_dict = {}
+  for file_path in safetensors_files:
+    with safe_open(file_path, framework="pt") as f:
+      for key in f.keys():
+        state_dict[key] = f.get_tensor(key).to(torch.bfloat16)
+  # Load the state_dict into the model
+  return state_dict
+
+
+def instantiate_model_from_repo_id(
+    repo_id,
+    env,
+):
+  """Create model instance by hf model id.+"""
+  model_dir = _hf_dir(repo_id)
+  if not os.path.exists(model_dir) or not os.listdir(model_dir):
+    # no weights has been downloaded
+    _hf_download(repo_id, model_dir, FLAGS.hf_token)
+  model_info = model_id_to_class.get(repo_id)
+  assert model_info is not None
+
+  env.device = "meta"
+  model = model_info.model_class.from_hf_model_id(repo_id, env)
+  weights = _load_weights(model_dir)
+  updated_keys = model.get_hf_names_to_real_name()
+  for name, updated in updated_keys.items():
+    if name in weights:
+      val = weights.pop(name)
+      weights[updated] = val
+
+  model.load_state_dict(weights, assign=True, strict=False)
+
+  return model
+  ## QQ do i need to set the weights onto the model?
+
+
+def _hf_download(
+    repo_id: str, dest_directory: str, hf_token: Optional[str] = None
+) -> None:
+  os.makedirs(dest_directory, exist_ok=True)
+  try:
+    if not hf_token:
+      hf_token = os.environ.get("HF_TOKEN")
+    if not hf_token:
+      # NOTE: setting true allows hf to read from the config folder.
+      hf_token = True
+    snapshot_download(
+        repo_id,
+        local_dir=dest_directory,
+        local_dir_use_symlinks=False,
+        token=hf_token,
+        allow_patterns=[
+            "model-?????-of-?????.safetensors",
+            "*.json",
+            "*.model",
+        ],
+    )
+  except HTTPError as e:
+    if e.response.status_code == 401:
+      print(
+          "Please use huggingface-cli login to authenticate "
+          "to download private checkpoints."
+      )
+      print("OR, pass `hf_token=...` explicitly.")
+    raise e

--- a/jetstream_pt/model_base.py
+++ b/jetstream_pt/model_base.py
@@ -1,0 +1,79 @@
+import abc
+import itertools
+from typing import Dict, Any, Optional
+import dataclasses
+from collections import defaultdict
+import torch
+
+
+def _get_hf_name(module, key):
+  if hasattr(module, "attr_to_property") and key in module.attr_to_property:
+    return module.attr_to_property[key].huggingface_name
+  return None
+
+
+def _gather_names(module, myprefix, hf_prefix, result):
+  for key, _ in itertools.chain(
+      module.named_parameters(recurse=False),
+      module.named_buffers(recurse=False),
+  ):
+    hf_name = _get_hf_name(module, key) or key
+    result[hf_prefix + hf_name] = myprefix + key
+
+  for name, child in module.named_children():
+    hf_name = _get_hf_name(module, name) or name
+    _gather_names(
+        child, myprefix + name + ".", hf_prefix + hf_name + ".", result
+    )
+
+
+def _gather_sharding_axis(module, myprefix, result):
+  if hasattr(module, "attr_to_property"):
+    for key, val in module.attr_to_property.items():
+      if val.sharding_axis is not None:
+        result[myprefix + key] = val.sharding_axis
+
+  for name, child in module.named_children():
+    _gather_sharding_axis(child, myprefix + name + ".", result)
+
+
+@dataclasses.dataclass
+class AttrProperty:
+  """Attributes attached to model weights."""
+
+  huggingface_name: Optional[str] = None
+  sharding_axis: Optional[int] = None
+
+
+class ModuleBase(torch.nn.Module, metaclass=abc.ABCMeta):
+  """nn Module that allows attaching properties"""
+
+  attr_to_property: Dict[str, Any]
+
+  def __init__(self):
+    super().__init__()
+    self.attr_to_property = defaultdict(AttrProperty)
+
+  def get_hf_names_to_real_name(self):
+    """Return a dict of attr names to it's hf name."""
+    result = {}
+    _gather_names(self, "", "", result)
+    return result
+
+  def get_sharding_annotations(self):
+    """Return a dict of attr names to it's sharding dim."""
+    result = {}
+    _gather_sharding_axis(self, "", result)
+    return result
+
+  def hf_name(self, orig_name, hf_name):
+    """Set it's alternative name for a attribute or submodule."""
+    self.attr_to_property[orig_name].huggingface_name = hf_name
+
+  def annotate_sharding(self, name, axis):
+    """Set sharding name for a attribute or submodule."""
+    self.attr_to_property[name].sharding_axis = axis
+
+  def drop_weight(self, key):
+    """list out names to discard."""
+    return False

--- a/jetstream_pt/quantize_model.py
+++ b/jetstream_pt/quantize_model.py
@@ -1,0 +1,15 @@
+import torch
+from .layers import create_quantized_from_nn_linear
+
+
+def quantize_model(float_model, config):
+  """Apply quantization to linear layers."""
+
+  def quantize_nn_mod(float_model):
+    for name, mod in float_model.named_modules():
+      if isinstance(mod, torch.nn.Linear):
+        new_mod = create_quantized_from_nn_linear(mod, config)
+        setattr(float_model, name, new_mod)
+
+  float_model.apply(quantize_nn_mod)
+  return float_model

--- a/jetstream_pt/ray_worker.py
+++ b/jetstream_pt/ray_worker.py
@@ -269,13 +269,6 @@ class PyTorchRayWorker:
   # pylint: disable-next=all
   def sharding_by_name(self, name):
 
-    # This allows easier way to edit shardings
-    """
-    for key, val in self.env._data.experimental_sharding_axis_override.items():
-      if name.endswith(key):
-        return self.env.sharding_by_axis(val)
-    """
-
     if "weight_scaler" in name:
       return self.x_sharding
     if "tok_embeddings." in name:

--- a/jetstream_pt/torchjax.py
+++ b/jetstream_pt/torchjax.py
@@ -11,6 +11,9 @@ It serves 2 purposes:
    how it looks like in torch_xla2.
 """
 
+import torch
+from torch.utils import _pytree as pytree
+
 import torch_xla2
 import torch_xla2.interop
 
@@ -23,6 +26,20 @@ def to_torch(tensors):
   return torch_xla2.default_env().j2t_iso(tensors)
 
 
+def from_torch_with_copy(tensors):
+  """Convert torch tensor to Jax Array."""
+
+  def convert_tensor(t):
+    if isinstance(t, torch_xla2.tensor.XLATensor2):
+      return t.jax()
+    return torch_xla2.tensor.t2j(t)
+
+  return pytree.tree_map_only(torch.Tensor, convert_tensor, tensors)
+
+
 def from_torch(tensors):
-  """Unwrap a XLATensor into jax Array."""
+  """Unwrap a XLATensor into jax Array.
+
+  Will raise if passed in a torch.Tensor that is not XLATensor
+  """
   return torch_xla2.default_env().t2j_iso(tensors)

--- a/tests/test_hf_names.py
+++ b/tests/test_hf_names.py
@@ -1,0 +1,61 @@
+import unittest
+import torch
+from jetstream_pt.model_base import ModuleBase
+
+
+class TestModuleBase(unittest.TestCase):
+
+  def test_get_hf_names_to_real_name(self):
+
+    class MyModule(ModuleBase):
+
+      def __init__(self):
+        super().__init__()
+        self.linear1 = torch.nn.Linear(10, 20)
+        self.linear2 = torch.nn.Linear(20, 30)
+        self.hf_name("linear1", "model.my_linear1")
+        self.hf_name("linear2", "model.my_linear2")
+        self.param = torch.nn.Parameter(torch.randn(10))
+        self.hf_name("param", "model.param")
+
+    module = MyModule()
+    expected_mapping = {
+        "model.my_linear1.weight": "linear1.weight",
+        "model.my_linear1.bias": "linear1.bias",
+        "model.my_linear2.weight": "linear2.weight",
+        "model.my_linear2.bias": "linear2.bias",
+        "model.param": "param",
+    }
+
+    self.assertEqual(module.get_hf_names_to_real_name(), expected_mapping)
+
+  def test_get_sharding_annotations(self):
+    class MyModule(ModuleBase):
+
+      def __init__(self):
+        super().__init__()
+        self.linear = torch.nn.Linear(10, 20)
+        self.embedding = torch.nn.Embedding(100, 50)
+        self.inner = InnerModule()
+
+    class InnerModule(ModuleBase):
+
+      def __init__(self):
+        super().__init__()
+        self.fc = torch.nn.Linear(50, 100)
+
+    module = MyModule()
+    module.annotate_sharding("linear.weight", 0)
+    module.annotate_sharding("embedding.weight", 1)
+    module.inner.annotate_sharding("fc.weight", 2)
+
+    expected_mapping = {
+        "linear.weight": 0,
+        "embedding.weight": 1,
+        "inner.fc.weight": 2,
+    }
+    self.assertEqual(module.get_sharding_annotations(), expected_mapping)
+
+
+if __name__ == "__main__":
+  unittest.main()


### PR DESCRIPTION
## Strategy to support HF models:

Each model that needs to support alternative names (i.e. HF) names, inherit from ModuleBase. and defines HF names for it's parameters and submodules, via `self.hf_name` call.

ModuleBase defines `get_hf_names_to_real_name` that returns hf name to the model name; which the loader can then use to remap the names before loading.

Modules inside of layers.py (Attention) should inherit ModuleBase but shouldnt define any mappings, because it might be used in different models. Let those models to define the mapping to it's corresponding HF checkpoints.

## Flags are organized in the following principles:

1. if a flag is used on only one file, define it there.
2. if a flag is for something internal for testing (like use_qkv); 
3. if a flag is likely to be modified for unit test; then use the Environment to store it.
4. Try to have least amount of flags that the users need to touch. 

## Commandline entry point

The new entry point will by jetstream.cli / it will remain inside of jetstream_pt folder so it's importable from tests.
Install script will put it in the PATH so people can invoke it as a command without typing `python`. 

```
python -m jetstream_pt.cli list
``` 
Lists the supported model

```
python -m jetstream_pt.cli serve --model_id ... --hf_token=...
```
runs the server

## Currently this only works for llama2 and llama3

## TODOS:

* Mixtral Model
* Quantization
* Gemma
* Install as command
