### PR TITLE
Add layer id in scope for each TransformerBlock layer

### DIFF
--- a/jetstream_pt/third_party/llama/model_exportable.py
+++ b/jetstream_pt/third_party/llama/model_exportable.py
@@ -232,7 +232,7 @@ class Transformer(nn.Module):
     ), f"Number of caches ({len(caches)}) and layers ({len(self.layers)}) dont match"
     end = None if start is None else (start + input_pos) % self.env.cache_len
     for layer, cache in zip(self.layers, caches):
-      with jax.named_scope("TransformerBlock"):
+      with jax.named_scope("TransformerBlock_Layer_" + str(layer.layer_id)):
         h = layer(
             h,
             freqs_cis,


### PR DESCRIPTION
All the TransformerBlock layer share a giant scope name, it's hard to debug and check details of profile for a layer. This PR adding layer id in scope for each TransformerBlock layer, there is scope boundary between layers, engineer can go to individual layer to check profile details.   