### PR TITLE
add enable jax profiler to run_server

### DIFF
--- a/run_server.py
+++ b/run_server.py
@@ -32,6 +32,8 @@ flags.DEFINE_string(
     "available servers",
 )
 flags.DEFINE_integer("prometheus_port", 0, "")
+flags.DEFINE_bool("enable_jax_profiler", False, "enable jax profiler")
+flags.DEFINE_integer("jax_profiler_port", 9999, "port of JAX profiler server")
 
 
 # pylint: disable-next=all
@@ -62,6 +64,8 @@ def main(argv: Sequence[str]):
       config=server_config,
       devices=devices,
       metrics_server_config=metrics_server_config,
+      enable_jax_profiler=FLAGS.enable_jax_profiler,
+      jax_profiler_port=FLAGS.jax_profiler_port,
   )
   print("Started jetstream_server....")
   jetstream_server.wait_for_termination()


### PR DESCRIPTION
- passes profiler arguments to server launch as optional
- uses instructions provided [here](https://github.com/google/JetStream/blob/main/docs/profiling-with-jax-profiler-and-tensorboard.md) for how to port forward from remote to local browser

example:
```
python run_server.py 
--size=8b 
--batch_size=1 
--max_cache_length=128 
--quantize_weights=false  
--quantize_kv_cache=true 
--checkpoint_path=".../models" 
--tokenizer_path=".../models/tokenizer.model" 
--model_name=llama-3
--sharding_config="default_shardings/llama.yaml"
--temperature=0.5
--sampling_algorithm="weighted"
--enable_jax_profiler=True # defaults to port 9999
```

Test when enabled on v5e-1:
```
python deps/JetStream/jetstream/tools/requester.py \
--tokenizer ".../models/tokenizer.model" 
Proxy backend support is not added
Sending request to: 0.0.0.0:9000
Prompt: Today is a good day
Response:  to be
```
<img width="1319" alt="Screenshot 2024-07-01 at 10 46 45 AM" src="https://github.com/google/jetstream-pytorch/assets/24945384/bfa5ea43-3ad4-437c-b9cb-0024ece145b8">

Test when disabled (defaults):
```
python deps/JetStream/jetstream/tools/requester.py \
--tokenizer ".../models/tokenizer.model" 
Proxy backend support is not added
Sending request to: 0.0.0.0:9000
Prompt: Today is a good day
Response:  to be
```