### PR TITLE
Fix exception in ray_worker

### DIFF
--- a/jetstream_pt/ray_worker.py
+++ b/jetstream_pt/ray_worker.py
@@ -350,7 +350,9 @@ class PyTorchRayWorker:
     new_mask = mask.at[:, current_position].set(0)
     if self.env.quant_config.enable_kv_quantization:
       caches_obj = [
-          cache_manager.Int8KVCacheGenerate(k, v, ks, vs, input_indexes, env=self.env)
+          cache_manager.Int8KVCacheGenerate(
+              k, v, ks, vs, input_indexes, env=self.env
+          )
           for (k, v), (ks, vs) in torchjax.to_torch(
               list(zip(caches, cache_scales))
           )

--- a/jetstream_pt/ray_worker.py
+++ b/jetstream_pt/ray_worker.py
@@ -350,7 +350,7 @@ class PyTorchRayWorker:
     new_mask = mask.at[:, current_position].set(0)
     if self.env.quant_config.enable_kv_quantization:
       caches_obj = [
-          cache_manager.Int8KVCacheGenerate(k, v, ks, vs, input_indexes)
+          cache_manager.Int8KVCacheGenerate(k, v, ks, vs, input_indexes, env=self.env)
           for (k, v), (ks, vs) in torchjax.to_torch(
               list(zip(caches, cache_scales))
           )
@@ -358,7 +358,7 @@ class PyTorchRayWorker:
     else:
       caches_obj = [
           cache_manager.KVCacheGenerate(
-              k, v, input_indexes, self.cache_sharding
+              k, v, input_indexes, self.cache_sharding, env=self.env
           )
           for k, v in torchjax.to_torch(caches)
       ]


### PR DESCRIPTION
The cache manager recently added a parameter for env: https://github.com/google/jetstream-pytorch/blob/main/jetstream_pt/cache_manager.py#L94

But this is not passed in the Ray worker: https://github.com/google/jetstream-pytorch/blob/main/jetstream_pt/ray_worker.py#L353

This will cause the Ray process to crash when the cache manager tries to access self.env: https://github.com/google/jetstream-pytorch/blob/main/jetstream_pt/cache_manager.py#L106