### PR TITLE
Set JAX_PLATFORMS to "tpu, cpu" for ray worker

### DIFF
--- a/jetstream_pt/ray_engine.py
+++ b/jetstream_pt/ray_engine.py
@@ -4,6 +4,7 @@ from typing import Any, Iterable, Optional, Union, Tuple, List
 
 import numpy as np
 import ray
+from ray.runtime_env import RuntimeEnv
 from ray.util.accelerators import tpu
 
 from jetstream.engine import engine_api, tokenizer_pb2
@@ -241,7 +242,8 @@ def create_pytorch_ray_engine(
   ), f"num_hosts (current value {num_hosts}) should be a positive number"
   # pylint: disable-next=all
   engine_worker_with_tpu_resource = PyTorchRayWorker.options(
-      resources={"TPU": 4}
+      resources={"TPU": 4},
+      runtime_env=RuntimeEnv(env_vars={"JAX_PLATFORMS": "tpu,cpu"}),
   )
   engine_workers = []
   for _ in range(num_hosts):


### PR DESCRIPTION
Issue: The Ray worker could fail to actuall acquire the TPU devices if another process is already using the TPU. This would cause Jax to fall back to CPUs in the Ray worker process.

Fix: If running with Ray, all processes by default should have JAX_PLATFORMS set to `cpu` (this can be set from the yaml configuration, which is not included in this PR). When a Ray worker is created, override the runtime environment to `tpu,cpu`. This ensures that the Ray worker can acquire access to the TPU device.