### PR TITLE
Set accumulate type to bf16 in activation quant

### DIFF
--- a/jetstream_pt/layers.py
+++ b/jetstream_pt/layers.py
@@ -148,7 +148,7 @@ class WeightOnlyPerChannelQuantizedLinear(torch.nn.Module):
             self.weight,
             (((2,), (1)), ((), ())),
             None,
-            jnp.int32.dtype,
+            jnp.bfloat16.dtype,
         )
       result = result * self.weight_scaler
       if self.quantize_activation:

--- a/jetstream_pt/layers.py
+++ b/jetstream_pt/layers.py
@@ -139,7 +139,8 @@ class WeightOnlyPerChannelQuantizedLinear(torch.nn.Module):
       if not self.quantize_activation:
         result = F.linear(inputs, self.weight)
       else:
-        # We have to call jax because we need to do dot(int8, int8)->int32.
+        # We have to call jax because we need to specify the output dtype of dot
+        # dot(int8, int8)->bf16.
         # This semantic cannot be represented in torch. The inferred output dtype
         # will be int8 in torch, causing the dot result to overflow.
         result = torchjax.call_jax(


### PR DESCRIPTION
XLA generate a more optimized graph in this way

Before the change, some collective ops are working on int32 mamtul, with this change those becomes bf16 (Expected). Latency is improved by ~10% compared with per-channel int8 weight only quant baseline, on llama2 70B BS=96