### PR TITLE
Fixed exhausted bug between head and workers

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ Note: Get address ip and port information from ray head.
 Here is an example to run the server with ray for llama2 7B model:
 
 ```bash
+export DISABLE_XLA2_PJRT_TEST="true"
 python run_server_with_ray.py --tpu_chips=16 --num_hosts=4 --worker_chips=4 -model_name=$model_name          --size=7b --batch_size=96 --max_cache_length=2048 --quantize_weights=$quantize --quantize_type=$quantize_type --quantize_kv_cache=$quantize --checkpoint_path=$output_ckpt_dir   --tokenizer_path=$tokenizer_path --sharding_config="default_shardings/llama.yaml"
 ```
 

--- a/install_everything.sh
+++ b/install_everything.sh
@@ -39,5 +39,5 @@ git submodule update --init --recursive
 pip show google-jetstream && pip uninstall -y google-jetstream
 pip show torch_xla2 && pip uninstall -y torch_xla2
 pip install -e .
-pip install -U jax[tpu]==0.4.31 -f https://storage.googleapis.com/jax-releases/libtpu_releases.html
+pip install -U jax[tpu]==0.4.30 -f https://storage.googleapis.com/jax-releases/libtpu_releases.html
 pip install -U torch==2.3.1+cpu --index-url https://download.pytorch.org/whl/cpu

--- a/install_everything.sh
+++ b/install_everything.sh
@@ -39,5 +39,5 @@ git submodule update --init --recursive
 pip show google-jetstream && pip uninstall -y google-jetstream
 pip show torch_xla2 && pip uninstall -y torch_xla2
 pip install -e .
-pip install -U jax[tpu]==0.4.30 -f https://storage.googleapis.com/jax-releases/libtpu_releases.html
+pip install -U jax[tpu]==0.4.31 -f https://storage.googleapis.com/jax-releases/libtpu_releases.html
 pip install -U torch==2.3.1+cpu --index-url https://download.pytorch.org/whl/cpu

--- a/run_interactive_multiple_host.py
+++ b/run_interactive_multiple_host.py
@@ -57,7 +57,7 @@ def create_engine():
       sharding_config=FLAGS.sharding_config,
       num_hosts=_NUM_HOSTS.value,
       worker_chips=_WORKER_CHIPS.value,
-      tpu_chips=_TPU_CHIPS,
+      tpu_chips=_TPU_CHIPS.value,
   )
 
   print("Initialize engine", time.perf_counter() - start)


### PR DESCRIPTION
Recent xla2 change call jax.devices() in init state, all the TPU been used by head, it caused all the worker throw below errors:

> RuntimeError: Unable to initialize backend 'tpu': ABORTED: The TPU is already in use by process with pid .. 

I submitted https://github.com/pytorch/xla/pull/7769 to fix the xla2 initialization issue. This PR applied the xla2 fix and updated the readme. 

