### PR TITLE
fix ray engine crashes on multihost

### DIFF
--- a/jetstream_pt/ray_worker.py
+++ b/jetstream_pt/ray_worker.py
@@ -466,9 +466,6 @@ class PyTorchRayWorker:
       logits = logits[0]
 
     token = np.argmax(logits[true_length - 1])
-    updated_caches = multihost_utils.process_allgather(
-        updated_caches, tiled=True
-    )
     prefix = Prefix(token, updated_caches, true_length)
     self.prefix_queue.put(prefix, block=False)
 
@@ -490,7 +487,7 @@ class PyTorchRayWorker:
         samples_per_slot=1,
     )
 
-    return prefix, result
+    return None, result
 
   def _convert_to_np_caches(
       self, caches: List[Tuple[jax.Array, jax.Array]]


### PR DESCRIPTION
Fix https://github.com/google/jetstream-pytorch/issues/150 without all_gather the kv cache