### PR TITLE
Switch to NP from Jax to  improve attention manager performance

### DIFF
--- a/tests/test_kv_cache_manager.py
+++ b/tests/test_kv_cache_manager.py
@@ -93,9 +93,10 @@ class PageAttentnioTest(parameterized.TestCase):
     decode_caches = _insert_prefill(8, 2, 1)
     decode_caches = _insert_prefill(13, 2, 3)
 
-    lens = jnp.asarray([3, 8, 0, 13, 0])
+    lens = np.asarray([3, 8, 0, 13, 0])
     pam.fill_new_pages(lens)
-    page_token_indices = pam.get_page_token_indices(lens)
+    np_page_token_indices = pam.get_page_token_indices(lens)
+    page_token_indices = jnp.asarray(np_page_token_indices)
     page_token_indices = torchjax.to_torch(page_token_indices)
 
     caches_obj = [

--- a/tests/test_page_attention.py
+++ b/tests/test_page_attention.py
@@ -157,23 +157,23 @@ class PageAttentionTest(parameterized.TestCase):
     slot = 1
     seq_len = 8
     pam.reserve_pages_insert(slot, seq_len)
-    expected_slot_page_indices = jnp.asarray([0, 1])
+    expected_slot_page_indices = np.asarray([0, 1])
     slot_page_indices = pam.page_indices[slot][0:2]
     self.assertTrue(
-        jnp.array_equal(slot_page_indices, expected_slot_page_indices)
+        np.array_equal(slot_page_indices, expected_slot_page_indices)
     )
 
-    lens = jnp.asarray([0, seq_len, 0])
+    lens = np.asarray([0, seq_len, 0])
     pam.fill_new_pages(lens)
-    expected_slot_page_indices = jnp.asarray([0, 1, 2, 19])
+    expected_slot_page_indices = np.asarray([0, 1, 2, 19])
     slot_page_indices = pam.page_indices[slot]
     self.assertTrue(
-        jnp.array_equal(slot_page_indices, expected_slot_page_indices)
+        np.array_equal(slot_page_indices, expected_slot_page_indices)
     )
 
-    expected_0_page_indices = jnp.asarray([19, 19, 19, 19])
+    expected_0_page_indices = np.asarray([19, 19, 19, 19])
     zer0_page_indices = pam.page_indices[0][0:4]
-    self.assertTrue(jnp.array_equal(zer0_page_indices, expected_0_page_indices))
+    self.assertTrue(np.array_equal(zer0_page_indices, expected_0_page_indices))
 
   def test_get_page_token_indices(self):
     env, _ = self._make_env()
@@ -188,18 +188,18 @@ class PageAttentionTest(parameterized.TestCase):
     pam.reserve_pages_insert(3, 13)
     pam.reserve_pages_insert(0, 3)
 
-    lens = jnp.asarray([3, 8, 0, 13, 0])
+    lens = np.asarray([3, 8, 0, 13, 0])
     pam.fill_new_pages(lens)
 
     page_token_indices = pam.get_page_token_indices(lens)
 
-    expected_page_indices = jnp.asarray([6, 7, 5])
-    expected_token_indices = jnp.asarray([3, 4, 9])
+    expected_page_indices = np.asarray([6, 7, 5])
+    expected_token_indices = np.asarray([3, 4, 9])
     self.assertTrue(
-        jnp.array_equal(page_token_indices[0], expected_page_indices)
+        np.array_equal(page_token_indices[0], expected_page_indices)
     )
     self.assertTrue(
-        jnp.array_equal(page_token_indices[1], expected_token_indices)
+        np.array_equal(page_token_indices[1], expected_token_indices)
     )
 
 


### PR DESCRIPTION
Current Jax implementation is slow. The operation array is tiny, leverage NP compute in CPU can boost the performance.    

The performance improved >30x. Below are two benchmark comparison before vs after this PR: 

**Before**
`
Total: 16 ms,  fill_new_page: 3ms, get_page_token_indices: 13ms
`

**After** 
`
Total: 0.5 ms, to_nparray: 0.1 ms, fill_new_page: 0.01ms,  get_page_token_indices: 0.05 ms to_jax_array:0.3 ms
`